### PR TITLE
rpmem: (trivial) fix typo of rpm_deep_persist

### DIFF
--- a/src/librpmem/rpmem.c
+++ b/src/librpmem/rpmem.c
@@ -641,7 +641,7 @@ rpmem_persist(RPMEMpool *rpp, size_t offset, size_t length, unsigned lane)
 }
 
 /*
- * rpmem_deep_persit -- deep flush operation on target node
+ * rpmem_deep_persist -- deep flush operation on target node
  *
  * rpp           -- remote pool handle
  * offset        -- offset in pool


### PR DESCRIPTION
Fix typo at the description of rpmem_deep_persist.